### PR TITLE
Filter for only references cited in this document

### DIFF
--- a/content/recipes/interoperability/bridgedb-recipe.md
+++ b/content/recipes/interoperability/bridgedb-recipe.md
@@ -428,7 +428,7 @@ You can find ready-made methods to map using R and Python for the given use case
 
 ---
 ```{bibliography} bridgedb/BridgeDb.bib
-
+  :filter: docname in docnames
 ```
 
 ___


### PR DESCRIPTION
Following https://sphinxcontrib-bibtex.readthedocs.io/en/latest/usage.html#local-bibliographies

And update https://github.com/egonw/the-fair-cookbook/pull/1/files#diff-f32ec2efb7d3f07d308840c784583d4275080d665b3872c8b78ba7ae476fc4d2L430 to point to the global `.bib` file.